### PR TITLE
Add support for rendering log markers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <description>A lightweight SLF4J backend.</description>
 
     <properties>
-        <java.version>1.6</java.version>
+        <java.version>1.8</java.version>
         <test.java.version>1.8</test.java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- When changing, update StaticLoggerBinder.REQUESTED_API_VERSION as well -->

--- a/src/main/java/com/darkyen/tproll/logfunctions/FileLogFunction.java
+++ b/src/main/java/com/darkyen/tproll/logfunctions/FileLogFunction.java
@@ -2,17 +2,19 @@ package com.darkyen.tproll.logfunctions;
 
 import com.darkyen.tproll.LogFunction;
 import com.darkyen.tproll.TPLogger;
+import com.darkyen.tproll.util.RenderedMarker;
 import com.darkyen.tproll.util.TimeFormatter;
 import org.joda.time.Duration;
 import org.slf4j.Marker;
 
 import java.io.File;
+import java.util.Iterator;
 
 /**
  * LogFunction which logs to a file.
  * Actual file handling is done through {@link ILogFileHandler} interface.
  *
- * @see LogFileHandler default implementation of ILogFileHandler
+ * @see FileLogFunction default implementation of ILogFileHandler
  */
 public class FileLogFunction extends LogFunction {
 
@@ -80,12 +82,25 @@ public class FileLogFunction extends LogFunction {
                 timeFormatter.format(time, sb);
                 sb.append(' ');
             }
-            sb.append(alignedLevelName(level)).append(']').append(' ').append(name).append(':').append(' ');
+            sb.append(alignedLevelName(level));
+            appendMarker(sb, marker, false);
+            sb.append(']').append(' ').append(name).append(':').append(' ');
             sb.append(content).append('\n');
 
             logFileHandler.log(sb);
 
             sb.setLength(0);
+        }
+    }
+
+    private void appendMarker(StringBuilder sb, Marker marker, boolean startWithSpace) {
+        if (marker instanceof RenderedMarker) {
+            if (startWithSpace) sb.append(' ');
+            sb.append("| ");
+            sb.append(marker.getName());
+        }
+        for (Iterator<Marker> it = marker.iterator(); it.hasNext(); ) {
+            appendMarker(sb, it.next(), true);
         }
     }
 

--- a/src/main/java/com/darkyen/tproll/logfunctions/FileLogFunction.java
+++ b/src/main/java/com/darkyen/tproll/logfunctions/FileLogFunction.java
@@ -2,13 +2,13 @@ package com.darkyen.tproll.logfunctions;
 
 import com.darkyen.tproll.LogFunction;
 import com.darkyen.tproll.TPLogger;
-import com.darkyen.tproll.util.RenderedMarker;
 import com.darkyen.tproll.util.TimeFormatter;
 import org.joda.time.Duration;
 import org.slf4j.Marker;
 
 import java.io.File;
-import java.util.Iterator;
+
+import static com.darkyen.tproll.util.RenderableMarker.appendMarker;
 
 /**
  * LogFunction which logs to a file.
@@ -83,24 +83,13 @@ public class FileLogFunction extends LogFunction {
                 sb.append(' ');
             }
             sb.append(alignedLevelName(level));
-            appendMarker(sb, marker, false);
+            appendMarker(sb, marker, true, false);
             sb.append(']').append(' ').append(name).append(':').append(' ');
             sb.append(content).append('\n');
 
             logFileHandler.log(sb);
 
             sb.setLength(0);
-        }
-    }
-
-    private void appendMarker(StringBuilder sb, Marker marker, boolean startWithSpace) {
-        if (marker instanceof RenderedMarker) {
-            if (startWithSpace) sb.append(' ');
-            sb.append("| ");
-            sb.append(marker.getName());
-        }
-        for (Iterator<Marker> it = marker.iterator(); it.hasNext(); ) {
-            appendMarker(sb, it.next(), true);
         }
     }
 

--- a/src/main/java/com/darkyen/tproll/logfunctions/SimpleLogFunction.java
+++ b/src/main/java/com/darkyen/tproll/logfunctions/SimpleLogFunction.java
@@ -2,12 +2,14 @@ package com.darkyen.tproll.logfunctions;
 
 import com.darkyen.tproll.LogFunction;
 import com.darkyen.tproll.TPLogger;
+import com.darkyen.tproll.util.RenderedMarker;
 import com.darkyen.tproll.util.TerminalColor;
 import com.darkyen.tproll.util.TimeFormatter;
 import org.joda.time.format.DateTimeFormatterBuilder;
 import org.slf4j.Marker;
 
 import java.io.PrintStream;
+import java.util.Iterator;
 
 import static com.darkyen.tproll.util.TerminalColor.*;
 
@@ -94,6 +96,8 @@ public abstract class SimpleLogFunction extends LogFunction {
         }
 
         black(sb);
+        appendMarker(sb, marker, false);
+        black(sb);
         sb.append(']');
         purple(sb);
         sb.append(' ');
@@ -108,6 +112,19 @@ public abstract class SimpleLogFunction extends LogFunction {
         logLine(level, sb);
 
         sb.setLength(0);
+    }
+
+    private void appendMarker(StringBuilder sb, Marker marker, boolean startWithSpace) {
+        if (marker instanceof RenderedMarker) {
+            black(sb);
+            if (startWithSpace) sb.append(' ');
+            sb.append("| ");
+            yellow(sb);
+            sb.append(marker.getName());
+        }
+        for (Iterator<Marker> it = marker.iterator(); it.hasNext(); ) {
+            appendMarker(sb, it.next(), true);
+        }
     }
 
     protected abstract void logLine(byte level, CharSequence formattedContent);

--- a/src/main/java/com/darkyen/tproll/logfunctions/SimpleLogFunction.java
+++ b/src/main/java/com/darkyen/tproll/logfunctions/SimpleLogFunction.java
@@ -2,15 +2,14 @@ package com.darkyen.tproll.logfunctions;
 
 import com.darkyen.tproll.LogFunction;
 import com.darkyen.tproll.TPLogger;
-import com.darkyen.tproll.util.RenderedMarker;
 import com.darkyen.tproll.util.TerminalColor;
 import com.darkyen.tproll.util.TimeFormatter;
 import org.joda.time.format.DateTimeFormatterBuilder;
 import org.slf4j.Marker;
 
 import java.io.PrintStream;
-import java.util.Iterator;
 
+import static com.darkyen.tproll.util.RenderableMarker.appendMarker;
 import static com.darkyen.tproll.util.TerminalColor.*;
 
 /**
@@ -96,7 +95,7 @@ public abstract class SimpleLogFunction extends LogFunction {
         }
 
         black(sb);
-        appendMarker(sb, marker, false);
+        appendMarker(sb, marker, true, true);
         black(sb);
         sb.append(']');
         purple(sb);
@@ -112,19 +111,6 @@ public abstract class SimpleLogFunction extends LogFunction {
         logLine(level, sb);
 
         sb.setLength(0);
-    }
-
-    private void appendMarker(StringBuilder sb, Marker marker, boolean startWithSpace) {
-        if (marker instanceof RenderedMarker) {
-            black(sb);
-            if (startWithSpace) sb.append(' ');
-            sb.append("| ");
-            yellow(sb);
-            sb.append(marker.getName());
-        }
-        for (Iterator<Marker> it = marker.iterator(); it.hasNext(); ) {
-            appendMarker(sb, it.next(), true);
-        }
     }
 
     protected abstract void logLine(byte level, CharSequence formattedContent);

--- a/src/main/java/com/darkyen/tproll/util/RenderableMarker.java
+++ b/src/main/java/com/darkyen/tproll/util/RenderableMarker.java
@@ -1,0 +1,42 @@
+package com.darkyen.tproll.util;
+
+import org.slf4j.Marker;
+
+import java.util.Iterator;
+
+import static com.darkyen.tproll.util.TerminalColor.black;
+import static com.darkyen.tproll.util.TerminalColor.yellow;
+
+/**
+ * Every Marker implementing this interface will get rendered by the log function
+ */
+public interface RenderableMarker extends Marker {
+
+    /**
+     * @return the label to be used for rendering with LogFunction
+     */
+    default String getLabel() {
+        return getName();
+    }
+
+
+    static void appendMarker(StringBuilder sb, Marker marker, boolean firstInList, boolean useColors) {
+        boolean rendered = false;
+
+        if (marker instanceof RenderableMarker) {
+            if (useColors) black(sb);
+            if (firstInList) sb.append(' ');
+            sb.append("| ");
+            if (useColors) yellow(sb);
+            sb.append(((RenderableMarker)marker).getLabel());
+            rendered = true;
+        }
+
+        if (marker.hasReferences()) {
+            for (Iterator<Marker> it = marker.iterator(); it.hasNext(); ) {
+                appendMarker(sb, it.next(), firstInList && !rendered, useColors);
+            }
+        }
+    }
+}
+

--- a/src/main/java/com/darkyen/tproll/util/RenderedMarker.java
+++ b/src/main/java/com/darkyen/tproll/util/RenderedMarker.java
@@ -1,6 +1,0 @@
-package com.darkyen.tproll.util;
-
-/**
- *
- */
-public abstract class RenderedMarker extends SimpleMarker {}

--- a/src/main/java/com/darkyen/tproll/util/RenderedMarker.java
+++ b/src/main/java/com/darkyen/tproll/util/RenderedMarker.java
@@ -1,0 +1,6 @@
+package com.darkyen.tproll.util;
+
+/**
+ *
+ */
+public abstract class RenderedMarker extends SimpleMarker {}

--- a/src/main/java/com/darkyen/tproll/util/SimpleMarker.java
+++ b/src/main/java/com/darkyen/tproll/util/SimpleMarker.java
@@ -178,4 +178,33 @@ public abstract class SimpleMarker implements Marker {
         }
         return -1;
     }
+
+    /**
+     * Convenience function, which creates new SimpleRenderableMarker
+     */
+    public static SimpleRenderableMarker withLabel(String label) {
+        return new SimpleRenderableMarker(label);
+    }
+
+    /**
+     * SimpleMarker with RenderableMarker interface
+     */
+    public static class SimpleRenderableMarker extends SimpleMarker implements RenderableMarker {
+        private final String label;
+
+        public SimpleRenderableMarker(String label) {
+            this.label = label;
+        }
+
+        @Override
+        public String getName() {
+            return "Renderable[" + label + "]";
+        }
+
+        @Override
+        public String getLabel() {
+            return label;
+        }
+    }
+
 }


### PR DESCRIPTION
This PR includes new `class RenderableMarker extends SimpleMarker` and updates to `SimpleLogFunction` and `FileLogFunction` that renders these markers at the beginning of the logline.

Sample formatted output from running automated JUnit batch:
```
[DEBUG| [2] 0-1] SqlParserTest: Found SQL command: <CREATE TABLE IF NOT EXISTS Settings (key TEXT PRIMARY KEY,     val TEXT)>
[DEBUG| [2] 0-1] SqlParserTest: Found SQL command: <REPLACE INTO Settings (key, val) VALUES ('db_scheme_version', 1)>
[DEBUG| [3] comment_torture_test] SqlParserTest: Found SQL command: <CREATE TABLE IF NOT EXISTS Settings (key TEXT PRIMARY KEY, val TEXT)>
[DEBUG| [3] comment_torture_test] SqlParserTest: Found SQL command: <REPLACE  INTO Settings (key,  val ) VALUES (      'db/*_scheme--*/_version', 1 )>
[INFO | webStaticRequest()] test: No ktor.deployment.watch patterns specified, automatic reload is not active
[DEBUG| webStaticRequest() | ExampleMarker] SampleTest: Received 871 bytes
```